### PR TITLE
Add integration seam to Logger

### DIFF
--- a/websocket-sharp/Logger.cs
+++ b/websocket-sharp/Logger.cs
@@ -32,6 +32,16 @@ using System.IO;
 
 namespace WebSocketSharp
 {
+  public interface IWebSocketLogger
+  {
+      void Debug (string message);
+      void Error (string message);
+      void Fatal (string message);
+      void Info (string message);
+      void Trace (string message);
+      void Warn (string message);
+  }
+
   /// <summary>
   /// Provides a set of methods and properties for logging.
   /// </summary>
@@ -49,7 +59,7 @@ namespace WebSocketSharp
   ///   <see cref="Logger.Output"/> to any <c>Action&lt;LogData, string&gt;</c> delegate.
   ///   </para>
   /// </remarks>
-  public class Logger
+  public class Logger : IWebSocketLogger
   {
     #region Private Fields
 

--- a/websocket-sharp/Server/WebSocketBehavior.cs
+++ b/websocket-sharp/Server/WebSocketBehavior.cs
@@ -78,7 +78,7 @@ namespace WebSocketSharp.Server
     /// A <see cref="Logger"/> that provides the logging functions,
     /// or <see langword="null"/> if the WebSocket connection isn't established.
     /// </value>
-    protected Logger Log {
+    protected IWebSocketLogger Log {
       get {
         return _websocket != null ? _websocket.Log : null;
       }

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -92,7 +92,7 @@ namespace WebSocketSharp
                                     _handshakeRequestChecker;
     private bool                    _ignoreExtensions;
     private bool                    _inContinuation;
-    private volatile Logger         _logger;
+    private volatile IWebSocketLogger _logger;
     private Queue<MessageEventArgs> _messageEventQueue;
     private uint                    _nonceCount;
     private string                  _origin;
@@ -426,12 +426,12 @@ namespace WebSocketSharp
     /// <value>
     /// A <see cref="Logger"/> that provides the logging functions.
     /// </value>
-    public Logger Log {
+    public IWebSocketLogger Log {
       get {
         return _logger;
       }
 
-      internal set {
+      set {
         _logger = value;
       }
     }


### PR DESCRIPTION
WebSocket's logging mechanism does not have an interface or a setting to let you override the default implementation. This PR fixes that. 
