### PR TITLE
Add nuget support and hyperon version alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ obj
 *.user
 *.userprefs
 UpgradeLog*.*
+*.nupkg

--- a/websocket-sharp.nuspec
+++ b/websocket-sharp.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>websocket-sharp</id>
+    <version>@build.number@</version>
+    <authors>sta</authors>
+    <owners>sta</owners>
+    <summary>TabbedOut fork of the popular </summary>
+    <description>A C# implementation of the WebSocket protocol client and server http://sta.github.io/websocket-sharp</description>
+    <projectUrl>http://sta.github.io/websocket-sharp/</projectUrl>
+    <licenseUrl>https://github.com/sta/websocket-sharp/blob/master/LICENSE.txt</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>websocket</tags>
+  </metadata>
+  @files@
+</package>

--- a/websocket-sharp.nuspec
+++ b/websocket-sharp.nuspec
@@ -5,7 +5,7 @@
     <version>@build.number@</version>
     <authors>sta</authors>
     <owners>sta</owners>
-    <summary>TabbedOut fork of the popular </summary>
+    <summary>TabbedOut fork of the popular C# websocket library. We are maintaining this fork for feature additions which sta does not wish to support. Mainly support for extra headers and testability.</summary>
     <description>A C# implementation of the WebSocket protocol client and server http://sta.github.io/websocket-sharp</description>
     <projectUrl>http://sta.github.io/websocket-sharp/</projectUrl>
     <licenseUrl>https://github.com/sta/websocket-sharp/blob/master/LICENSE.txt</licenseUrl>

--- a/websocket-sharp/AssemblyInfo.cs
+++ b/websocket-sharp/AssemblyInfo.cs
@@ -7,20 +7,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("websocket-sharp")]
 [assembly: AssemblyDescription("A C# implementation of the WebSocket protocol client and server")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("websocket-sharp.dll")]
-[assembly: AssemblyCopyright("sta.blockhead")]
-[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCopyright("sta")]
 [assembly: AssemblyCulture("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion("1.0.2.*")]
-
-// The following attributes are used to specify the signing key for the assembly, 
-// if desired. See the Mono documentation for more information about signing.
-
-//[assembly: AssemblyDelaySign(false)]
-//[assembly: AssemblyKeyFile("")]

--- a/websocket-sharp/websocket-sharp.csproj
+++ b/websocket-sharp/websocket-sharp.csproj
@@ -89,6 +89,9 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\SolutionInfo.cs">
+      <Link>SolutionInfo.cs</Link>
+    </Compile>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Ext.cs" />
     <Compile Include="IWebSocket.cs" />


### PR DESCRIPTION
Hyperon is now able to build websocket-sharp as a Nuget. 
